### PR TITLE
Owners endpoint to be sorted by recency

### DIFF
--- a/2022-07-04-change-to-nft-owners-endpoint.md
+++ b/2022-07-04-change-to-nft-owners-endpoint.md
@@ -29,5 +29,6 @@ Nothing needs to be done as it is not a breaking change
 
 ## Link to Moralis Forum for disucssions
 
+https://forum.moralis.io/t/changes-to-the-nft-owners-endpoint-nft-address-owners-and-nft-address-token-id-owners-from-july-4-2022/17001
 
 We have staff monitoring forum 24/7 - while we don't monitor github as much - so we need everyone to discuss in the forum

--- a/2022-07-04-change-to-nft-owners-endpoint.md
+++ b/2022-07-04-change-to-nft-owners-endpoint.md
@@ -1,4 +1,4 @@
-# Changes to the NFT owners endpoint: `/nft/:address/owners` and `/nft/:address/:token_id/owners` from July 5, 2022
+# Changes to the NFT owners endpoint: `/nft/:address/owners` and `/nft/:address/:token_id/owners` from July 4, 2022
 
 ## Products affected
 - [ ] SDK

--- a/2022-07-04-change-to-nft-owners-endpoint.md
+++ b/2022-07-04-change-to-nft-owners-endpoint.md
@@ -13,7 +13,7 @@
 
 ## Description of the change
 
-To provide a consistent and recent return of data based on recent activity on the nfts, the endpoints `/nft/:address/owners` and `/nft/:address/:token_id/owners` will no longer be ordered by the `transfer_index` column but instead by the `updated_at` column.
+The endpoints `/nft/:address/owners` and `/nft/:address/:token_id/owners` will no longer be ordered based on descending block number but rather based on descending activity timestamp to give a consistent return of data based on recent activity on the nfts.
 
 ## What exactly can break?
 
@@ -25,7 +25,7 @@ Nothing needs to be done as it is not a breaking change
 
 ## When will this change go live and be mandatory?
 
-2022-07-05
+2022-07-04
 
 ## Link to Moralis Forum for disucssions
 

--- a/2022-07-05-change-to-nft-owners-endpoint.md
+++ b/2022-07-05-change-to-nft-owners-endpoint.md
@@ -8,7 +8,7 @@
 - [ ] Servers
 
 ## Is this a breaking change?
-- [] yes
+- [ ] yes
 - [X] no
 
 ## Description of the change

--- a/2022-07-05-change-to-nft-owners-endpoint.md
+++ b/2022-07-05-change-to-nft-owners-endpoint.md
@@ -1,0 +1,33 @@
+# Changes to the NFT owners endpoint: `/nft/:address/owners` and `/nft/:address/:token_id/owners` from July 5, 2022
+
+## Products affected
+- [ ] SDK
+- [X] API
+- [ ] Admin UI
+- [ ] Nodes
+- [ ] Servers
+
+## Is this a breaking change?
+- [] yes
+- [X] no
+
+## Description of the change
+
+To provide a consistent and recent return of data based on recent activity on the nfts, the endpoints `/nft/:address/owners` and `/nft/:address/:token_id/owners` will no longer be ordered by the `transfer_index` column but instead by the `updated_at` column.
+
+## What exactly can break?
+
+It is not a breaking change
+
+## How to ensure my app won't break?
+
+Nothing needs to be done as it is not a breaking change
+
+## When will this change go live and be mandatory?
+
+2022-07-05
+
+## Link to Moralis Forum for disucssions
+
+
+We have staff monitoring forum 24/7 - while we don't monitor github as much - so we need everyone to discuss in the forum


### PR DESCRIPTION
# Changes to the NFT owners endpoint: `/nft/:address/owners` and `/nft/:address/:token_id/owners` from July 4, 2022

## Products affected
- [ ] SDK
- [X] API
- [ ] Admin UI
- [ ] Nodes
- [ ] Servers

## Is this a breaking change?
- [ ] yes
- [X] no

## Description of the change

The endpoints `/nft/:address/owners` and `/nft/:address/:token_id/owners` will no longer be ordered based on descending block number but rather based on descending activity timestamp to give a consistent return of data based on recent activity on the nfts.

## What exactly can break?

It is not a breaking change

## How to ensure my app won't break?

Nothing needs to be done as it is not a breaking change

## When will this change go live and be mandatory?

2022-07-04

## Link to Moralis Forum for disucssions

https://forum.moralis.io/t/changes-to-the-nft-owners-endpoint-nft-address-owners-and-nft-address-token-id-owners-from-july-4-2022/17001

We have staff monitoring forum 24/7 - while we don't monitor github as much - so we need everyone to discuss in the forum